### PR TITLE
soong: allow overriding header files

### DIFF
--- a/android/config.go
+++ b/android/config.go
@@ -1377,6 +1377,10 @@ func (c *deviceConfig) DeviceKernelHeaderDirs() []string {
 	return c.config.productVariables.DeviceKernelHeaders
 }
 
+func (c *deviceConfig) TargetSpecificHeaderPath() string {
+	return String(c.config.productVariables.TargetSpecificHeaderPath)
+}
+
 // JavaCoverageEnabledForPath returns whether Java code coverage is enabled for
 // path. Coverage is enabled by default when the product variable
 // JavaCoveragePaths is empty. If JavaCoveragePaths is not empty, coverage is

--- a/android/variable.go
+++ b/android/variable.go
@@ -351,6 +351,8 @@ type productVariables struct {
 
 	DeviceKernelHeaders []string `json:",omitempty"`
 
+	TargetSpecificHeaderPath *string `json:",omitempty"`
+
 	ExtraVndkVersions []string `json:",omitempty"`
 
 	NamespacesToExport []string `json:",omitempty"`

--- a/cc/compiler.go
+++ b/cc/compiler.go
@@ -337,6 +337,16 @@ func (compiler *baseCompiler) compilerFlags(ctx ModuleContext, flags Flags, deps
 	tc := ctx.toolchain()
 	modulePath := android.PathForModuleSrc(ctx).String()
 
+	additionalIncludeDirs := ctx.DeviceConfig().TargetSpecificHeaderPath()
+	if len(additionalIncludeDirs) > 0 {
+		// devices can have multiple paths in TARGET_SPECIFIC_HEADER_PATH
+		// add -I in front of all of them
+		if (strings.Contains(additionalIncludeDirs, " ")) {
+			additionalIncludeDirs = strings.ReplaceAll(additionalIncludeDirs, " ", " -I")
+		}
+		flags.Local.CommonFlags = append(flags.Local.CommonFlags, "-I" + additionalIncludeDirs)
+	}
+
 	compiler.srcsBeforeGen = android.PathsForModuleSrcExcludes(ctx, compiler.Properties.Srcs, compiler.Properties.Exclude_srcs)
 	compiler.srcsBeforeGen = append(compiler.srcsBeforeGen, deps.GeneratedSources...)
 


### PR DESCRIPTION
Includes:

  Author: Jan Altensen <info@stricted.net>
  Date:   Sat Aug 7 19:41:59 2021 +0200

    soong: move header override to compiler.go

     * library.go only covers libraries

    Change-Id: I3374999d6b364dd1bbc2060996964ee7b04493e7

Change-Id: Ia9d2210605c5927b529fbe9485b0e5abd079f487